### PR TITLE
Updated to Node-Wit 3.3.x API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit-middleware-witai",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "A middleware for using Wit.ai in a Botkit-powered bot",
   "main": "src/botkit-middleware-witai.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/howdyai/botkit-middleware-witai#readme",
   "dependencies": {
-    "node-wit": "^3.2.2"
+    "node-wit": "^3.3.0"
   },
   "devDependencies": {
     "jscs": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/howdyai/botkit-middleware-witai#readme",
   "dependencies": {
-    "node-wit": "^3.3.0"
+    "node-wit": "^3.3.2"
   },
   "devDependencies": {
     "jscs": "^2.8.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "botkit-middleware-witai",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A middleware for using Wit.ai in a Botkit-powered bot",
   "main": "src/botkit-middleware-witai.js",
   "scripts": {
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/howdyai/botkit-middleware-witai#readme",
   "dependencies": {
-    "node-wit": "^2.0.0"
+    "node-wit": "^3.2.2"
   },
   "devDependencies": {
     "jscs": "^2.8.0"

--- a/readme.md
+++ b/readme.md
@@ -52,6 +52,13 @@ Using the Wit hears middleware tells Botkit to look for Wit.ai intents
 information, and match using this information instead of the built in
 pattern matching function.
 
+You must make a an `intent` entity in the understandings area of wit.ai
+and train it to register certain expressions.
+
+I.e "intent" -> "weather"
+
+Expression: "What is the weather?" and that maps to the weather intent.
+
 Unless you want to directly access the information returned by wit,
 you can use this transparently by enabling bot the `receive` and `hears`
 middlewares.

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -47,7 +47,7 @@ module.exports = function(config) {
     };
 
     middleware.hears = function(tests, message) {
-        if (message.entities.intent) {
+        if (message.entities && message.entities.intent) {
             for (var i = 0; i < message.entities.intent.length; i++) {
                 for (var t = 0; t < tests.length; t++) {
                     if (message.entities.intent[i].value == tests[t]) {

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -1,9 +1,22 @@
-'use strict';
 const Logger = require('node-wit').Logger;
 const levels = require('node-wit').logLevels;
 const Wit = require('node-wit').Wit;
 
 const logger = new Logger(levels.DEBUG);
+
+// not used at the moment
+const actions = {
+    say(sessionId, context, message, cb) {
+        console.log(message);
+        cb();
+    },
+    merge(sessionId, context, entities, message, cb) {
+        cb(context);
+    },
+    error(sessionId, context, error) {
+        console.log(error.message);
+    }
+};
 
 module.exports = function(config) {
 
@@ -25,7 +38,7 @@ module.exports = function(config) {
                 if (error) {
                     next(error);
                 } else {
-                    // no support for multiple outcomes, is it needed for this?
+                    // not sure how to handle multiple outcomes right now
                     message.entities = data.outcomes[0].entities;
                     next();
                 }
@@ -47,7 +60,5 @@ module.exports = function(config) {
         return false;
     };
 
-
     return middleware;
-
 };

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -1,4 +1,9 @@
-var wit = require('node-wit');
+'use strict';
+const Logger = require('node-wit').Logger;
+const levels = require('node-wit').logLevels;
+const Wit = require('node-wit').Wit;
+
+const logger = new Logger(levels.DEBUG);
 
 module.exports = function(config) {
 
@@ -10,30 +15,29 @@ module.exports = function(config) {
         config.minimum_confidence = 0.5;
     }
 
-    var middleware = {};
+    const client = new Wit(config.token, actions, logger);
+
+    const middleware = {};
 
     middleware.receive = function(bot, message, next) {
         if (message.text) {
-            wit.captureTextIntent(config.token, message.text, function(err, res) {
-                if (err) {
-                    next(err);
+            client.message(message.text, (error, data) => {
+                if (error) {
+                    next(error);
                 } else {
-                    console.log(JSON.stringify(res));
-                    message.intents = res.outcomes;
+                    // no support for multiple outcomes, is it needed for this?
+                    message.entities = data.outcomes[0].entities;
                     next();
                 }
             });
         }
-
     };
 
     middleware.hears = function(tests, message) {
-
-        if (message.intents) {
-            for (var i = 0; i < message.intents.length; i++) {
+        if (message.entities.intent) {
+            for (var i = 0; i < message.entities.intent.length; i++) {
                 for (var t = 0; t < tests.length; t++) {
-                    if (message.intents[i].intent == tests[t] &&
-                        message.intents[i].confidence >= config.minimum_confidence) {
+                    if (message.entities.intent[i].value == tests[t]) {
                         return true;
                     }
                 }

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -41,6 +41,8 @@ module.exports = function(config) {
                     next();
                 }
             });
+        } else {
+            next();
         }
     };
 

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -6,14 +6,14 @@ var logger = new Logger(levels.DEBUG);
 
 // not used at the moment
 var actions = {
-    say(sessionId, context, message, cb) {
+    say: function say(sessionId, context, message, cb) {
         console.log(message);
         cb();
     },
-    merge(sessionId, context, entities, message, cb) {
+    merge: function merge(sessionId, context, entities, message, cb) {
         cb(context);
     },
-    error(sessionId, context, error) {
+    error: function error(sessionId, context, error) {
         console.log(error.message);
     }
 };

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -29,7 +29,9 @@ module.exports = function(config) {
     var middleware = {};
 
     middleware.receive = function(bot, message, next) {
-        if (message.text) {
+        // Only parse messages of type text and mention the bot.
+        // Otherwise it would send every single message to wit (probably don't want that).
+        if (message.text && message.text.indexOf(bot.identity.id) > -1) {
             client.message(message.text, function(error, data) {
                 if (error) {
                     next(error);

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -1,8 +1,4 @@
-var Logger = require('node-wit').Logger;
-var levels = require('node-wit').logLevels;
 var Wit = require('node-wit').Wit;
-
-var logger = new Logger(levels.DEBUG);
 
 // not used at the moment
 var actions = {
@@ -28,7 +24,7 @@ module.exports = function(config) {
         config.minimum_confidence = 0.5;
     }
 
-    var client = new Wit(config.token, actions, logger);
+    var client = new Wit(config.token, actions);
 
     var middleware = {};
 

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -36,8 +36,7 @@ module.exports = function(config) {
                 if (error) {
                     next(error);
                 } else {
-                    // not sure how to handle multiple outcomes right now
-                    message.entities = data.outcomes[0].entities;
+                    message.entities = data.entities;
                     next();
                 }
             });
@@ -50,7 +49,8 @@ module.exports = function(config) {
         if (message.entities && message.entities.intent) {
             for (var i = 0; i < message.entities.intent.length; i++) {
                 for (var t = 0; t < tests.length; t++) {
-                    if (message.entities.intent[i].value == tests[t]) {
+                    if (message.entities.intent[i].value == tests[t] &&
+                        message.entities.intent[i].confidence >= config.minimum_confidence) {
                         return true;
                     }
                 }

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -1,11 +1,11 @@
-const Logger = require('node-wit').Logger;
-const levels = require('node-wit').logLevels;
-const Wit = require('node-wit').Wit;
+var Logger = require('node-wit').Logger;
+var levels = require('node-wit').logLevels;
+var Wit = require('node-wit').Wit;
 
-const logger = new Logger(levels.DEBUG);
+var logger = new Logger(levels.DEBUG);
 
 // not used at the moment
-const actions = {
+var actions = {
     say(sessionId, context, message, cb) {
         console.log(message);
         cb();
@@ -28,9 +28,9 @@ module.exports = function(config) {
         config.minimum_confidence = 0.5;
     }
 
-    const client = new Wit(config.token, actions, logger);
+    var client = new Wit(config.token, actions, logger);
 
-    const middleware = {};
+    var middleware = {};
 
     middleware.receive = function(bot, message, next) {
         if (message.text) {

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -6,14 +6,14 @@ var logger = new Logger(levels.DEBUG);
 
 // not used at the moment
 var actions = {
-    say: function say(sessionId, context, message, cb) {
+    say: function(sessionId, context, message, cb) {
         console.log(message);
         cb();
     },
-    merge: function merge(sessionId, context, entities, message, cb) {
+    merge: function(sessionId, context, entities, message, cb) {
         cb(context);
     },
-    error: function error(sessionId, context, error) {
+    error: function(sessionId, context, error) {
         console.log(error.message);
     }
 };
@@ -34,7 +34,7 @@ module.exports = function(config) {
 
     middleware.receive = function(bot, message, next) {
         if (message.text) {
-            client.message(message.text, (error, data) => {
+            client.message(message.text, function(error, data) {
                 if (error) {
                     next(error);
                 } else {


### PR DESCRIPTION
This uses the new Node-Wit 3.3.x API.

In order to maintain the intent style callback, simply create an entity named 'intent'.

This closes #4 
