### PR TITLE
Allow messages with only attachments to pass through

### DIFF
--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -24,6 +24,10 @@ module.exports = function(config) {
                 }
             });
         }
+        else if (message.attachments) {
+            message.intents = [];
+            next();
+        }
 
     };
 


### PR DESCRIPTION
Currently when a message with only an attachment is received (for example, a Facebook location message), the message gets caught up in this middleware and never reaches the controller. 

This is because in the following code for receiving, there is a check to see if it has text, and if it does not then `next()` is never called:

```
middleware.receive = function(bot, message, next) {
        if (message.text) {
            console.log('message has text')
            wit.captureTextIntent(config.token, message.text, function(err, res) {
                if (err) {
                    next(err);
                } else {
                    console.log(JSON.stringify(res));
                    message.intents = res.outcomes;
                    next();
                }
            });
        }
       // we should have something hear to pass through other types of messages even if they don't    have text
    };
```

I have added a simple `else if` check that will also pass through other messages, setting an empty array for its intents, and calling `next()`
