### PR TITLE
Parse messages that are directly messaging the bot

### DIFF
--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -32,7 +32,8 @@ module.exports = function(config) {
         // Only parse messages of type text and mention the bot or is directly messaging the bot.
         // Otherwise it would send every single message to wit (probably don't want that).
         if ((message.text && message.text.indexOf(bot.identity.id) > -1) ||
-            (message.user != bot.identity.id && message.channel && message.channel.match(/^D/))) {
+            (message.user != bot.identity.id &&
+             message.channel && message.channel.typeof === 'string' && message.channel.match(/^D/))) {
             client.message(message.text, function(error, data) {
                 if (error) {
                     next(error);

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -32,7 +32,7 @@ module.exports = function(config) {
         // Only parse messages of type text and mention the bot or is directly messaging the bot.
         // Otherwise it would send every single message to wit (probably don't want that).
         if ((message.text && message.text.indexOf(bot.identity.id) > -1) ||
-            (message.channel && message.channel.match(/^D/))) {
+            (message.user != bot.identity.id && message.channel && message.channel.match(/^D/))) {
             client.message(message.text, function(error, data) {
                 if (error) {
                     next(error);

--- a/src/botkit-middleware-witai.js
+++ b/src/botkit-middleware-witai.js
@@ -29,9 +29,10 @@ module.exports = function(config) {
     var middleware = {};
 
     middleware.receive = function(bot, message, next) {
-        // Only parse messages of type text and mention the bot.
+        // Only parse messages of type text and mention the bot or is directly messaging the bot.
         // Otherwise it would send every single message to wit (probably don't want that).
-        if (message.text && message.text.indexOf(bot.identity.id) > -1) {
+        if ((message.text && message.text.indexOf(bot.identity.id) > -1) ||
+            (message.channel && message.channel.match(/^D/))) {
             client.message(message.text, function(error, data) {
                 if (error) {
                     next(error);


### PR DESCRIPTION
This fixes a bug that filters out direct messages to the bot resulting in messages not being sent to wit. I've added a check if the message's channel starts with the letter "D". If so, don't filter out. "D" means it's a direct message to the bot.